### PR TITLE
Copy Assets directory with MSBuild instead of PowerShell

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,7 +14,7 @@
     <MakeDir Directories="$(BepInExDirectory)/plugins/MapStation/Assets" />
     <ItemGroup>
       <!-- Copy can't do directories, mark files with Include and copy that instead -->
-      <_Assets Include="$(SolutionDir)Assets\**\*" />
+      <_Assets Include="$(SolutionDir)Assets/**/*" />
     </ItemGroup>
     <Copy SourceFiles="@(_Assets)" DestinationFolder="$(BepInExDirectory)/plugins/MapStation" />
   </Target>


### PR DESCRIPTION
I don't set system-wide environment variables but rather MSBuild variables, which makes the PowerShell scripts a little annoying to use for me. Copying the Assets folder with an MSBuild task means I don't have to set a system-wide environment variable to build the project (I can just open it in Rider and click Build Solution).

The only downside seeming to be that it copies on each project individually when doing a solution-wide build. Desired behavior is copying once, only when assets need to be updated.

Alternative solution: Load a .env file from the MapStation directory in the PowerShell scripts? Maybe?